### PR TITLE
Swap padded space for am hours to a zero

### DIFF
--- a/get_ec2_events.sh
+++ b/get_ec2_events.sh
@@ -18,7 +18,7 @@ else
   ACCOUNT="default"
 fi
 
-TIMESTAMP=$(date +"%Y%m%d_%k%M%S")
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 EC2_REGIONS=$(aws ec2 describe-regions --region us-west-2 --output text | cut -f 3)
 
 echo "Getting instances for profile $ACCOUNT"


### PR DESCRIPTION
Awesome Script! I was planning write something very similar.

I tried this out this morning and it generated a csv with a space in it which was kind of annoying so I swapped the date format to be zero padded for hours less than 12 instead of space padded.

Heres the difference

``` bash
[myaccount]_us-east-1_found_instances_20150228_ 91206.csv
```

``` bash
[myaccount]_us-east-1_found_instances_20150228_092746.csv
```
